### PR TITLE
feat: Initial Client

### DIFF
--- a/crates/offeryn-core/src/lib.rs
+++ b/crates/offeryn-core/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod client;
 pub mod error;
 pub mod server;
 pub mod transport;
 
+pub use client::StdioClient;
 pub use error::McpError;
 pub use offeryn_types::{
     CallToolRequest, CallToolResult, Content, InitializeResult, ListToolsResult,

--- a/crates/offeryn-core/src/transport/mod.rs
+++ b/crates/offeryn-core/src/transport/mod.rs
@@ -1,4 +1,4 @@
-mod sse;
-mod stdio;
+pub(super) mod sse;
+pub(super) mod stdio;
 pub use sse::SseServerTransport;
 pub use stdio::StdioServerTransport;


### PR DESCRIPTION
Would like to get feedback on the direction I've gone so far, namely

1. The Client calls the Transport, as opposed to the the pattern used on the server side.
2. Having a client implementation per transport type (`StdioClient`, `SseClient`) as opposed to one type that owns a `T` such that `T: Transport`, where `Transport` is some trait that doesn't exist right now. This draft only has the initial work of a `StdioClient`, nothing for SSE yet.
3. Is switching to using generated types in `offeryn-types` out of scope for this work?