### PR TITLE
refactor: StdioTransport trait and server transport rename

### DIFF
--- a/crates/offeryn-core/src/transport/mod.rs
+++ b/crates/offeryn-core/src/transport/mod.rs
@@ -1,4 +1,4 @@
 mod sse;
 mod stdio;
-pub use sse::SseTransport;
-pub use stdio::StdioTransport;
+pub use sse::SseServerTransport;
+pub use stdio::StdioServerTransport;

--- a/crates/offeryn-core/src/transport/stdio.rs
+++ b/crates/offeryn-core/src/transport/stdio.rs
@@ -18,7 +18,7 @@ where
     stdout: W,
 }
 
-impl StdioTransport<tokio::io::Stdin, tokio::io::Stdout> {
+impl StdioServerTransport<tokio::io::Stdin, tokio::io::Stdout> {
     pub fn new(server: Arc<McpServer>) -> Self {
         Self {
             server,
@@ -28,7 +28,7 @@ impl StdioTransport<tokio::io::Stdin, tokio::io::Stdout> {
     }
 }
 
-impl<R, W> StdioTransport<R, W>
+impl<R, W> StdioServerTransport<R, W>
 where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
@@ -162,7 +162,7 @@ mod tests {
         let (client_reader, server_writer) = duplex(1024);
         let (server_reader, client_writer) = duplex(1024);
 
-        let transport = StdioTransport::with_streams(server, server_reader, server_writer);
+        let transport = StdioServerTransport::with_streams(server, server_reader, server_writer);
         let server_task = tokio::spawn(async move {
             transport.run().await.unwrap();
         });
@@ -182,7 +182,7 @@ mod tests {
 
         let mut client_writer = BufWriter::new(client_writer);
         let request_json = serde_json::to_vec(&request).unwrap();
-        StdioTransport::<DuplexStream, DuplexStream>::write_message(
+        StdioServerTransport::<DuplexStream, DuplexStream>::write_message(
             &mut client_writer,
             &request_json,
         )
@@ -191,7 +191,7 @@ mod tests {
 
         let mut client_reader = BufReader::new(client_reader);
         let response_bytes =
-            StdioTransport::<DuplexStream, DuplexStream>::read_message(&mut client_reader)
+            StdioServerTransport::<DuplexStream, DuplexStream>::read_message(&mut client_reader)
                 .await
                 .unwrap();
         let response: Response = serde_json::from_slice(&response_bytes).unwrap();

--- a/examples/calculator/src/main.rs
+++ b/examples/calculator/src/main.rs
@@ -1,5 +1,5 @@
 use offeryn::prelude::*;
-use offeryn::{McpServer, SseTransport};
+use offeryn::{McpServer, SseServerTransport};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing_subscriber::EnvFilter;
@@ -55,7 +55,7 @@ async fn main() {
     server.register_tools(Calculator::default()).await;
 
     // Create the router
-    let app = SseTransport::create_router(server);
+    let app = SseServerTransport::create_router(server);
 
     // Bind to localhost:3000
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/examples/stdio-calculator/src/main.rs
+++ b/examples/stdio-calculator/src/main.rs
@@ -1,5 +1,5 @@
 use offeryn::prelude::*;
-use offeryn::{McpServer, StdioTransport};
+use offeryn::{McpServer, StdioServerTransport};
 use std::sync::Arc;
 
 /// A simple calculator that can perform basic arithmetic operations
@@ -42,7 +42,7 @@ async fn main() {
     server.register_tools(Calculator::default()).await;
 
     // Create and run the stdio transport
-    let transport = StdioTransport::<tokio::io::Stdin, tokio::io::Stdout>::new(server);
+    let transport = StdioServerTransport::<tokio::io::Stdin, tokio::io::Stdout>::new(server);
 
     if let Err(e) = transport.run().await {
         eprintln!("Error: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub use offeryn_core::{transport::SseTransport, transport::StdioTransport, McpServer};
+pub use offeryn_core::{transport::SseServerTransport, transport::StdioServerTransport, McpServer};
 pub use offeryn_derive::tool;
 pub use offeryn_types as types;
 


### PR DESCRIPTION
- Renames `*Transport` to `*ServerTransport`
- Breaks common stdio transport functionality out into `StdioTransport` trait